### PR TITLE
Fix missing monthly_price and yearly_price columns in monthly_invoice…

### DIFF
--- a/database/migrations/2025_08_02_184653_add_missing_pricing_columns_to_monthly_invoice_settings_table.php
+++ b/database/migrations/2025_08_02_184653_add_missing_pricing_columns_to_monthly_invoice_settings_table.php
@@ -27,11 +27,11 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('monthly_invoice_settings', function (Blueprint $table) {
-            if (Schema::hasColumn('monthly_invoice_settings', 'monthly_price')) {
-                $table->dropColumn('monthly_price');
-            }
             if (Schema::hasColumn('monthly_invoice_settings', 'yearly_price')) {
                 $table->dropColumn('yearly_price');
+            }
+            if (Schema::hasColumn('monthly_invoice_settings', 'monthly_price')) {
+                $table->dropColumn('monthly_price');
             }
         });
     }


### PR DESCRIPTION
…_settings table

🔧 Database Schema Fix:
- Added missing monthly_price and yearly_price columns to monthly_invoice_settings table
- Fixed empty custom pricing migration (2025_08_01_214701)
- Created new migration (2025_08_02_184653) to add missing columns with proper defaults

🚨 Issue Resolved:
- Fixed SQLSTATE[42S22] error when creating new users
- Error: 'Unknown column monthly_price in INSERT INTO monthly_invoice_settings'
- Model expected monthly_price/yearly_price but database only had billing_amount

✅ Solution:
- Added conditional column checks to prevent duplicate column errors
- Set default values of 0 for both pricing columns
- Maintains backward compatibility with existing data

🧪 Tested:
- Migration runs successfully without errors
- User creation now works without database errors
- Ready for production deployment